### PR TITLE
Fix broken bookmark thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Live Demo: You can see this live on my site now: http://coreysnyder.me/test-page
 ## How to use
 Drop this line into your site-footer section in the ghost admin panel
 ```html
-  <script async src="https://cdn.jsdelivr.net/gh/coreysnyder04/fluidbox-ghost-blog-plugin@0.1.0/fluidbox-ghost-blog-plugin.min.js"></script>
+  <script async src="https://cdn.jsdelivr.net/gh/Torqu3Wr3nch/fluidbox-ghost-blog-plugin@0.1.1a/fluidbox-ghost-blog-plugin.min.js"></script>
 ```
 
 ### Customization

--- a/fluidbox-ghost-blog-plugin.js
+++ b/fluidbox-ghost-blog-plugin.js
@@ -41,8 +41,10 @@ window.fluidboxGhost = $.when(
 
     // Finds all of our
     $(targetImages.join(',')).each(function (index, el) {
-      $("<a href='" + $(this).attr('src') + "' class='zoom'></a>").insertAfter($(this));
-      $(this).appendTo($(this).next("a"));
+      if(!$(this).parent().hasClass("kg-bookmark-thumbnail")){
+        $("<a href='" + $(this).attr('src') + "' class='zoom'></a>").insertAfter($(this));
+        $(this).appendTo($(this).next("a"));
+      }
     });
 
     // Initialize Fluidbox


### PR DESCRIPTION
Updated with if statement to leave images with class "kg-bookmark-thumbnail" alone; we're not interested in expanding/breaking Ghost's bookmark card images.

Thanks to @torque3wr3nch